### PR TITLE
Fix to getUserMedia() first

### DIFF
--- a/src/conf/store/user.js
+++ b/src/conf/store/user.js
@@ -7,8 +7,8 @@ class UserStore {
     this.isVideoMuted = false;
     this.isAudioMuted = true;
     this.isSpeaking = false;
-    this.videoDeviceId = '';
-    this.audioDeviceId = '';
+    this.videoDeviceId = 'default';
+    this.audioDeviceId = 'default';
     this.videoDevices = [];
     this.audioDevices = [];
   }


### PR DESCRIPTION
Formerly, our control flow was like this.

- `enumerateDevices()`
  - get `deviceId` from first item in devices array
- `getUserMedia()` to get stream
- `getUserMedia()` again to update devices `label`
- then show up device selection view

In prior to make Safari as supported browser, it was needed to fix this because latest Safari TP returns empty `deviceId` before calling `getUserMedia()` causes error on calling real `getUserMedia()`.

This time, flow will be..

- `getUserMedia()` for user permission
- `enumerateDevices()`
  - get `deviceId` from first item in devices array
- `getUserMedia()` to get stream
- then show up device selection view

This changes does not affect current supported browsers.